### PR TITLE
Add (optional) flag to specify output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This is a downloader to download and update whole comics from https://tapas.io/.
  * The script will create an folder with the name and urlName (`name [urlName]`) of the comic in the current shell location (like git) and download all images of the comic into it.
  * If the script finds an folder with the name of the comic, it will only update, this can be disabled with `-f/--force`.
  * To get the verbose output use `-v/--verbose`.
- * To specify an base output path use `-o \desired\path` (If not specified, files and folders will be created where the script was run.)
+ * To specify an base output path use `-o/--output-dir \desired\path` (If not specified, files and folders will be created where the script was run.)
 
 ### Extra:
 If someone wants to quickly understand the code, here is the pseudo code of the pure download part:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This is a downloader to download and update whole comics from https://tapas.io/.
       ```
    * Execute the script
       ```
-      python tapas-dl.py [-h/--help] [-f/--force] [-v/--verbose] URL/name [URL/name ...]
+      python tapas-dl.py [-h/--help] [-f/--force] [-v/--verbose] URL/name [URL/name ...] [-o \output\path\]
       ```
       More exact usage in the next section
    * (thx @ [ONSKJ](https://github.com/ONSKJ) for help with Windows)
@@ -41,11 +41,12 @@ This is a downloader to download and update whole comics from https://tapas.io/.
 3. Start the download
  * Usage of `tapas-dl.py`:
  ```
- $ tapas-dl.py [-h/--help] [-f/--force] [-v/--verbose] URL/name [URL/name ...]
+ $ tapas-dl.py [-h/--help] [-f/--force] [-v/--verbose] URL/name [URL/name ...] [-o \output\path\] 
  ```
  * The script will create an folder with the name and urlName (`name [urlName]`) of the comic in the current shell location (like git) and download all images of the comic into it.
  * If the script finds an folder with the name of the comic, it will only update, this can be disabled with `-f/--force`.
  * To get the verbose output use `-v/--verbose`.
+ * To specify an base output path use `-o \desired\path` (If not specified, files and folders will be created where the script was run.)
 
 ### Extra:
 If someone wants to quickly understand the code, here is the pseudo code of the pure download part:

--- a/tapas-dl.py
+++ b/tapas-dl.py
@@ -52,7 +52,7 @@ parser.add_argument('url', metavar='URL/name', type=str, nargs='+',
 parser.add_argument('-f', '--force', action="store_true", help='Disables updater.')
 parser.add_argument('-v', '--verbose', action="store_true", help='Enables verbose mode.')
 parser.add_argument('-c', '--restrict-characters', action="store_true", help='Removes \'? < > \\ : * | " ^\' from file names')
-parser.add_argument('-o', type=str, nargs='?', default="", dest='baseDir', metavar='C:\\',
+parser.add_argument('-o', '--output-dir', type=str, nargs='?', default="", dest='baseDir', metavar='C:\\',
                     help='Output directory where comics should be placed.\nIf left blank, the script folder will be used.')
 
 args = parser.parse_args()


### PR DESCRIPTION
Added a(n optional) flag that allows the specification of an output directory.

I tested it against the comic downloading tool, and it works as expected!

I was unable to test the novel downloading portion, because the novel detection doesn't seem to work. I don't think it was my changes- I ran the code with none of my edits on several novels, and it detected them as comics. :/ 
I tried to figure out the 'ep-epub-contents' bit you were using to differentiate, but I don't know pyQuery enough to figure out exactly how you were doing it, or what might be wrong. (That text is present on both novel pages and comic pages.)

If you can figure out how to fix it, and would prefer I merge after that, feel free to say so and I'll rebase after the fix and submit this pull request again!