### PR TITLE
Add handling for comics with Early Access

### DIFF
--- a/tapas-dl.py
+++ b/tapas-dl.py
@@ -159,13 +159,12 @@ for urlCount, url in enumerate(args.url):
             # Test whether the page we have in mind is reachable
             pageReqest = requests.get(f'https://tapas.io/episode/{pageData["id"]}', headers={'user-agent': 'tapas-dl'}) 
             if pageReqest.status_code != 200: 
-                printLine('Error: "{}" page {}/{} not found. Page Request yielded: {} (Early Access page?)\n'.format(urlName,pageCount + pageOffset, len(data) + pageOffset,str(pageReqest.status_code)), True)
+                printLine('Error: "{}" page {}/{} not found. Page Request yielded: {} (Early Access page?)'.format(urlName,pageCount + pageOffset, len(data) + pageOffset,str(pageReqest.status_code)), True)
                 
                 # We failed to get this page. Add a single dummy entry we can find later.
-                pageData['title'] = "Error 404"
+                pageData['title'] = "PageUnavailable"
                 pageData['imgs'] = []
-                pageData['imgs'].append("Error 404")
-                #allImgCount += 1
+                pageData['imgs'].append("PageUnavailable")
                 
             else:
                 pageHtml = pq(f'https://tapas.io/episode/{pageData["id"]}', headers={'user-agent': 'tapas-dl'})
@@ -186,7 +185,8 @@ for urlCount, url in enumerate(args.url):
             
             for imgOfPageCount, img in enumerate(pageData['imgs']):
                 
-                if pageData['imgs'][0] != "Error 404":
+                # Download all the images for this page (if the first entry is not "PageUnavailable", indicating the page was unavailable when scraped for images).
+                if pageData['imgs'][0] != "PageUnavailable":
                 
                     with open(os.path.join(savePath, check_path('{} - {} - {} - {} - #{}.{}'.format(lead0(imgCount + imgOffset, allImgCount + imgOffset), lead0(pageCount + pageOffset, len(pageData) + pageOffset),
                                                                                                                            lead0(imgOfPageCount, len(pageData['imgs'])), pageData['title'],

--- a/tapas-dl.py
+++ b/tapas-dl.py
@@ -154,30 +154,42 @@ for urlCount, url in enumerate(args.url):
         # Get images from page from JS api
         allImgCount = 0
         for pageCount, pageData in enumerate(data):
-            printLine('Downloaded image data from {} images (pages {}/{})...'.format(allImgCount, pageCount + pageOffset, len(data) + pageOffset), True)
+            
+            # Try to parse the next comic page (This will fail with a 404 if the page is 'Early Access' only) See 'except' below
+            try:
+                pageHtml = pq(f'https://tapas.io/episode/{pageData["id"]}', headers={'user-agent': 'tapas-dl'})
+                
+                printLine('Downloaded image data from {} images (pages {}/{})...'.format(allImgCount, pageCount + pageOffset, len(data) + pageOffset), True)
 
-            pageHtml = pq(f'https://tapas.io/episode/{pageData["id"]}', headers={'user-agent': 'tapas-dl'})
+                pageData['title'] = pageHtml('.info__title').text()
 
-            pageData['title'] = pageHtml('.info__title').text()
+                pageData['imgs'] = []
+                for img in pageHtml('.content__img'):
+                    pageData['imgs'].append(pq(img).attr('data-src'))
 
-            pageData['imgs'] = []
-            for img in pageHtml('.content__img'):
-                pageData['imgs'].append(pq(img).attr('data-src'))
-
-                allImgCount += 1
+                    allImgCount += 1
+            except:
+                printLine('Unable to parse page {}/{})... (This page may be Early Access)'.format(pageCount + pageOffset, len(data) + pageOffset), True)
+                
+                
 
         # Download images
         imgCount = 0
         for pageCount, pageData in enumerate(data):
-            for imgOfPageCount, img in enumerate(pageData['imgs']):
-                with open(os.path.join(savePath, check_path('{} - {} - {} - {} - #{}.{}'.format(lead0(imgCount + imgOffset, allImgCount + imgOffset), lead0(pageCount + pageOffset, len(pageData) + pageOffset),
-                                                                                                                       lead0(imgOfPageCount, len(pageData['imgs'])), pageData['title'],
-                                                                                                                       pageData['id'], img[img.rindex('.') + 1:]), fat=args.restrict_characters)), 'wb') as f:
-                    f.write(requests.get(img).content)
+            
+            # Try to fetch the img data for this page (This will fail if it was skipped in the previous try/except block- possibly because the page is 'Early Access' only.)
+            try:
+                for imgOfPageCount, img in enumerate(pageData['imgs']):
+                    with open(os.path.join(savePath, check_path('{} - {} - {} - {} - #{}.{}'.format(lead0(imgCount + imgOffset, allImgCount + imgOffset), lead0(pageCount + pageOffset, len(pageData) + pageOffset),
+                                                                                                                           lead0(imgOfPageCount, len(pageData['imgs'])), pageData['title'],
+                                                                                                                           pageData['id'], img[img.rindex('.') + 1:]), fat=args.restrict_characters)), 'wb') as f:
+                        f.write(requests.get(img).content)
 
-                imgCount += 1
+                    imgCount += 1
 
-                printLine('Downloaded image {}/{} from page {}/{} ({}/{} images)...'.format(imgOfPageCount + 1, len(pageData['imgs']), pageCount + pageOffset, len(data) + pageOffset, imgCount + imgOffset, allImgCount + imgOffset), True)
+                    printLine('Downloaded image {}/{} from page {}/{} ({}/{} images)...'.format(imgOfPageCount + 1, len(pageData['imgs']), pageCount + pageOffset, len(data) + pageOffset, imgCount + imgOffset, allImgCount + imgOffset), True)
+            except:
+                printLine('Unable to download page {}/{})... (This page may be Early Access)'.format(pageCount + pageOffset, len(data) + pageOffset), True)
 
         if data != []:
             printLine('Downloaded {} images'.format(allImgCount))

--- a/tapas-dl.py
+++ b/tapas-dl.py
@@ -200,7 +200,7 @@ for urlCount, url in enumerate(args.url):
                     printLine('Error: No images available on page {}/{}.'.format(pageCount + pageOffset, len(data) + pageOffset), True)
 
         if data != []:
-            printLine('Downloaded {} images'.format(allImgCount))
+            printLine('Downloaded {} of {} images'.format(imgCount, allImgCount))
         else:
             printLine('Nothing to do')
 

--- a/tapas-dl.py
+++ b/tapas-dl.py
@@ -158,15 +158,17 @@ for urlCount, url in enumerate(args.url):
             
             # Test whether the page we have in mind is reachable
             pageReqest = requests.get(f'https://tapas.io/episode/{pageData["id"]}', headers={'user-agent': 'tapas-dl'}) 
-            if pageReqest.status_code != 200: 
+            if pageReqest.status_code != 200:
+                # This page was unavailable. Let the user know and add a single dummy image entry.
+                # (We will check for this when we go to download images.)
                 printLine('Error: "{}" page {}/{} not found. Page Request yielded: {} (Early Access page?)'.format(urlName,pageCount + pageOffset, len(data) + pageOffset,str(pageReqest.status_code)), True)
                 
-                # We failed to get this page. Add a single dummy entry we can find later.
                 pageData['title'] = "PageUnavailable"
                 pageData['imgs'] = []
                 pageData['imgs'].append("PageUnavailable")
                 
             else:
+                # If the page did not yield an access error, go ahead an scrape for image entries.
                 pageHtml = pq(f'https://tapas.io/episode/{pageData["id"]}', headers={'user-agent': 'tapas-dl'})
 
                 printLine('Downloaded image data from {} images (pages {}/{})...'.format(allImgCount, pageCount + pageOffset, len(data) + pageOffset), True)
@@ -185,9 +187,9 @@ for urlCount, url in enumerate(args.url):
             
             for imgOfPageCount, img in enumerate(pageData['imgs']):
                 
-                # Download all the images for this page (if the first entry is not "PageUnavailable", indicating the page was unavailable when scraped for images).
+                # Check if the first image entry is the fummy text that indicates the page was unavailable when we tried to scrape it.
                 if pageData['imgs'][0] != "PageUnavailable":
-                
+                    # If the entry isn't a dummy entry, go ahead and download the images it contains.
                     with open(os.path.join(savePath, check_path('{} - {} - {} - {} - #{}.{}'.format(lead0(imgCount + imgOffset, allImgCount + imgOffset), lead0(pageCount + pageOffset, len(pageData) + pageOffset),
                                                                                                                            lead0(imgOfPageCount, len(pageData['imgs'])), pageData['title'],
                                                                                                                            pageData['id'], img[img.rindex('.') + 1:]), fat=args.restrict_characters)), 'wb') as f:
@@ -197,7 +199,8 @@ for urlCount, url in enumerate(args.url):
 
                     printLine('Downloaded image {}/{} from page {}/{} ({}/{} images)...'.format(imgOfPageCount + 1, len(pageData['imgs']), pageCount + pageOffset, len(data) + pageOffset, imgCount + imgOffset, allImgCount + imgOffset), True)
                 else:
-                    printLine('Error: No images available on page {}/{}.'.format(pageCount + pageOffset, len(data) + pageOffset), True)
+                    # If the entry was a dummy entry, skip it and let the user know.
+                    printLine('Error: No images downloaded from page {}/{}.'.format(pageCount + pageOffset, len(data) + pageOffset), True)
 
         if data != []:
             printLine('Downloaded {} of {} images'.format(imgCount, allImgCount))

--- a/tapas-dl.py
+++ b/tapas-dl.py
@@ -149,8 +149,7 @@ for urlCount, url in enumerate(args.url):
         imgOffset = 0
 
     # Check if series is comic or novel
-    #if len(pq(f'https://tapas.io/episode/{data[0]["id"]}', headers={'user-agent': 'tapas-dl'})('.ep-epub-contents')) > 0:
-    if True:
+    if len(pq(f'https://tapas.io/episode/{data[0]["id"]}', headers={'user-agent': 'tapas-dl'})('.ep-epub-contents')) > 0:
         printLine('Detected comic')
         # Get images from page from JS api
         allImgCount = 0


### PR DESCRIPTION
Skips early access blocked strips instead of crashing.
Uses two try/except pairs, one for page parsing, and one for page downloading.

It's not exceptionally elegant, but it works!

This pull would resolve Issue #21 